### PR TITLE
Autocomplete only triggers on backslash

### DIFF
--- a/julia-utf.sublime-completions
+++ b/julia-utf.sublime-completions
@@ -1,8 +1,8 @@
 {
-    "scope": "source.julia",
+	"scope": "source.julia",
 
-    "completions": [
-        {"trigger": "\\textexclamdown", "contents": "¡" },
+	"completions": [
+		{"trigger": "\\textexclamdown", "contents": "¡" },
 		{"trigger": "\\sterling", "contents": "£" },
 		{"trigger": "\\yen", "contents": "¥" },
 		{"trigger": "\\textbrokenbar", "contents": "¦" },
@@ -2452,5 +2452,5 @@
 		{"trigger": "\\mttseven", "contents": "𝟽" },
 		{"trigger": "\\mtteight", "contents": "𝟾" },
 		{"trigger": "\\mttnine", "contents": "𝟿"}
-    ]
+	]
 }

--- a/julia-utf.sublime-completions
+++ b/julia-utf.sublime-completions
@@ -1,5 +1,5 @@
 {
-	"scope": "source.julia",
+	"scope": "source.julia keyword.operator.arithmetic.julia",
 
 	"completions": [
 		{"trigger": "\\textexclamdown", "contents": "¡" },

--- a/julia-utf.sublime-settings
+++ b/julia-utf.sublime-settings
@@ -1,0 +1,6 @@
+{
+    // Triggers auto complete after a backslash
+    "auto_complete_triggers": [
+        {"selector": "source.julia", "characters": "\\"}
+    ]
+}


### PR DESCRIPTION
Due to the fuzzy matching Sublime uses for triggering autocomplete this plugin was causing me a lot of grief when writing Julia code. I would be typing keywords like `end` and getting an `\endash` instead. I have updated the code such that the completions in this package are only triggered upon a backslash.

Change requires that you have a Julia syntax highlighting package installed (to define "keyword.operator.arithmetic.julia" scope).

Currently there is an issue where the defined "auto_complete_triggers" doesn't work from `julia-utf.sublime-settings`. Applying this setting in the User or Syntax Specific preferences causes this to work as expected.
